### PR TITLE
多个commit一并提交/合并pr时显示所有的commit id和commit message

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -52,12 +52,10 @@ jobs:
           MESSAGE_THREAD_ID: ${{ secrets.MESSAGE_THREAD_ID }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           CANARY: ${{ steps.sign_canary.outputs.signedReleaseFile }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_URL: ${{ github.event.head_commit.url }}
-          BOT_MESSAGE: |+
-            [New Release From Github](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            [${{ github.event.head_commit.message }}](${{ github.event.head_commit.url }})
         run: |
-          ESCAPED=`python3 -c 'import json,os,urllib.parse; print(urllib.parse.quote(json.dumps(os.environ["BOT_MESSAGE"])))'`
+          mkdir -p ${{ github.workspace }}/git_clone
+          git clone https://github.com/Cemiuiler-Development-Team/Cemiuiler.git ${{ github.workspace }}/git_clone -b main
+          cd ${{ github.workspace }}/git_clone
+          { echo -e '"Github CI\n```'; git log ${{ github.event.before }}..${{ github.event.after }} --pretty=format:"%h %s"; echo -n -e '\n```"'; } > ${{ github.workspace }}/git_log
+          ESCAPED="$(cat ${{ github.workspace }}/git_log | hexdump -v -e '/1 "%02X"' | sed 's/\(..\)/%\1/g')"
           curl -sL "https://api.telegram.org/bot${BOT_TOKEN}/sendMediaGroup?chat_id=${GROUP_ID}&message_thread_id=${MESSAGE_THREAD_ID}&media=%5B%7B%22type%22%3A%22document%22%2C%20%22media%22%3A%22attach%3A%2F%2Fcanary%22%2C%22parse_mode%22%3A%22MarkdownV2%22%2C%22caption%22%3A${ESCAPED}%7D%5D" -F canary="@${CANARY}"
-


### PR DESCRIPTION
由于tg机器人发送字数有限，commit稍微一多，那加上超链接后就会直接发送失败，所以移除了超链接。

如果markdown包含特殊字符，那必须要用反斜杠转义，否则发送失败，[如此所示](https://github.com/Cemiuiler-Development-Team/Cemiuiler/actions/runs/4914045389/jobs/8774909652#step:7:20) 。但转义字符比较复杂（其实也不复杂，一个sed命令就能解决，但我不知道有哪些特殊字符），所以用围栏代码块保护了起来。