### PR TITLE
修复 系统桌面-布局-主屏幕-顶部间距 在RELEASE-4.39.9.6586版本桌面失效

### DIFF
--- a/app/src/main/java/com/sevtinge/cemiuiler/module/home/layout/WorkspacePadding.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/home/layout/WorkspacePadding.java
@@ -12,9 +12,6 @@ public class WorkspacePadding extends BaseHook {
     Context mContext;
     Class<?> mDeviceConfig;
 
-    static int mHomeVersionCode;
-    final static int NEW_HOME_WORKSPACE_PADDING_TOP_VERSION = 439096586;
-
     @Override
     public void init() {
 
@@ -38,14 +35,15 @@ public class WorkspacePadding extends BaseHook {
         }
 
         if (mPrefsMap.getBoolean("home_layout_workspace_padding_top_enable")) {
-            if (mHomeVersionCode >= NEW_HOME_WORKSPACE_PADDING_TOP_VERSION) {
+            try {
+                // 新版本桌面，先标记，后续再做进一步修改
                 findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingTop", Context.class, new MethodHook() {
                     @Override
                     protected void before(MethodHookParam param) {
                         param.setResult(DisplayUtils.dip2px(mContext, mPrefsMap.getInt("home_layout_workspace_padding_top", 0)));
                     }
                 });
-            } else {
+            } catch (Throwable t) {
                 findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingTop", new MethodHook() {
                     @Override
                     protected void before(MethodHookParam param) {

--- a/app/src/main/java/com/sevtinge/cemiuiler/module/home/layout/WorkspacePadding.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/home/layout/WorkspacePadding.java
@@ -1,5 +1,7 @@
 package com.sevtinge.cemiuiler.module.home.layout;
 
+import static com.sevtinge.cemiuiler.utils.Helpers.getPackageVersionCode;
+
 import android.content.Context;
 
 import com.sevtinge.cemiuiler.module.base.BaseHook;
@@ -10,10 +12,14 @@ public class WorkspacePadding extends BaseHook {
     Context mContext;
     Class<?> mDeviceConfig;
 
+    static int mHomeVersionCode;
+    final static int NEW_HOME_WORKSPACE_PADDING_TOP_VERSION = 439096586;
+
     @Override
     public void init() {
 
         mDeviceConfig = findClassIfExists("com.miui.home.launcher.DeviceConfig");
+        mHomeVersionCode = getPackageVersionCode(lpparam);
 
         findAndHookMethod(mDeviceConfig, "Init", Context.class, boolean.class, new MethodHook() {
             @Override
@@ -32,12 +38,21 @@ public class WorkspacePadding extends BaseHook {
         }
 
         if (mPrefsMap.getBoolean("home_layout_workspace_padding_top_enable")) {
-            findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingTop", new MethodHook() {
-                @Override
-                protected void before(MethodHookParam param) {
-                    param.setResult(DisplayUtils.dip2px(mContext, mPrefsMap.getInt("home_layout_workspace_padding_top", 0)));
-                }
-            });
+            if (mHomeVersionCode >= NEW_HOME_WORKSPACE_PADDING_TOP_VERSION) {
+                findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingTop", Context.class, new MethodHook() {
+                    @Override
+                    protected void before(MethodHookParam param) {
+                        param.setResult(DisplayUtils.dip2px(mContext, mPrefsMap.getInt("home_layout_workspace_padding_top", 0)));
+                    }
+                });
+            } else {
+                findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingTop", new MethodHook() {
+                    @Override
+                    protected void before(MethodHookParam param) {
+                        param.setResult(DisplayUtils.dip2px(mContext, mPrefsMap.getInt("home_layout_workspace_padding_top", 0)));
+                    }
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
系统桌面-布局-主屏幕-顶部间距，在RELEASE-4.39.9.6586版本桌面失效