### PR TITLE
Introduced protections against system command injection

### DIFF
--- a/app/src/main/java/com/sevtinge/cemiuiler/module/hook/systemui/NotificationVolumeSeparateSlider.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/hook/systemui/NotificationVolumeSeparateSlider.java
@@ -10,6 +10,9 @@ import com.sevtinge.cemiuiler.utils.Helpers.MethodHook;
 import de.robv.android.xposed.XposedHelpers;
 
 public class NotificationVolumeSeparateSlider {
+    private NotificationVolumeSeparateSlider() {
+    }
+    
     public static void initHideDeviceControlEntry(ClassLoader pluginLoader) {
         int notifVolumeOnResId;
         int notifVolumeOffResId;

--- a/app/src/main/java/com/sevtinge/cemiuiler/utils/log/XposedLogUtils.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/utils/log/XposedLogUtils.java
@@ -10,6 +10,9 @@ import de.robv.android.xposed.XposedBridge;
 
 public class XposedLogUtils {
 
+private XposedLogUtils() {
+}
+
     private static boolean isDebugVersion = BuildConfig.BUILD_TYPE.contains("debug");
     private static boolean isReleaseVersion = BuildConfig.BUILD_TYPE.contains("release");
     private static boolean isDisableDetailLog = BaseHook.mPrefsMap.getBoolean("settings_disable_detailed_log");


### PR DESCRIPTION
This change hardens all instances of [Runtime#exec()](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html) to offer protection against attack.

Left unchecked, `Runtime#exec()` can execute any arbitrary system command. If an attacker can control part of the strings used to as program paths or arguments, they could execute arbitrary programs, install malware, and anything else they could do if they had a shell open on the application host.

Our change introduces a sandbox which protects the application:

```diff
+ import io.github.pixee.security.SystemCommand;
  ...
- Process p = Runtime.getRuntime().exec(command);
+ Process p = SystemCommand.runCommand(Runtime.getRuntime(), command);
```

The default restrictions applied are the following:
* **Prevent command chaining**. Many exploits work by injecting command separators and causing the shell to interpret a second, malicious command. The `SystemCommand#runCommand()` attempts to parse the given command, and throw a `SecurityException` if multiple commands are present.
* **Prevent arguments targeting sensitive files.** There is little reason for custom code to target sensitive system files like `/etc/passwd`, so the sandbox prevents arguments that point to these files that may be targets for exfiltration.

There are [more options for sandboxing](https://github.com/pixee/java-security-toolkit/blob/main/src/main/java/io/github/pixee/security/SystemCommand.java#L15) if you are interested in locking down system commands even more.

<details>
  <summary>More reading</summary>

  * [https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
  * [https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec%28%29+method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec%28%29+method)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/harden-process-creation](https://docs.pixee.ai/codemods/java/pixee_java_harden-process-creation)) ![]